### PR TITLE
Explicitly require 'fcntl'

### DIFF
--- a/lib/delayed_job_worker_pool/worker_pool.rb
+++ b/lib/delayed_job_worker_pool/worker_pool.rb
@@ -1,3 +1,5 @@
+require 'fcntl'
+
 module DelayedJobWorkerPool
   class WorkerPool
     SIGNALS = ['TERM', 'INT'].map(&:freeze).freeze


### PR DESCRIPTION
Without this, I get:

```
vendor/bundle/gems/delayed_job_worker_pool-0.2.2/lib/delayed_job_worker_pool/worker_pool.rb:172:in `make_file_descriptor_uninheritable': uninitialized constant IO::Fcntl (NameError)
```

Ruby 2.3/Rails 4.2.5
