### PR TITLE
Add ability to spawn pooled queues with dedicated worker procs.

### DIFF
--- a/bin/delayed_job_worker_pool
+++ b/bin/delayed_job_worker_pool
@@ -8,4 +8,4 @@ end
 require 'delayed_job_worker_pool'
 
 options = DelayedJobWorkerPool::DSL.load(ARGV[0])
-#DelayedJobWorkerPool::WorkerPool.new(options).run
+DelayedJobWorkerPool::WorkerPool.new(options).run

--- a/bin/delayed_job_worker_pool
+++ b/bin/delayed_job_worker_pool
@@ -8,4 +8,4 @@ end
 require 'delayed_job_worker_pool'
 
 options = DelayedJobWorkerPool::DSL.load(ARGV[0])
-DelayedJobWorkerPool::WorkerPool.new(options).run
+#DelayedJobWorkerPool::WorkerPool.new(options).run

--- a/delayed_job_worker_pool.gemspec
+++ b/delayed_job_worker_pool.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.executables   = ['delayed_job_worker_pool']
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 2.0'
+  spec.required_ruby_version = '>= 1.9.3'
 
   spec.add_dependency 'delayed_job', ['>= 3.0', '< 4.2']
 

--- a/lib/delayed_job_worker_pool/dsl.rb
+++ b/lib/delayed_job_worker_pool/dsl.rb
@@ -1,6 +1,6 @@
 module DelayedJobWorkerPool
   class DSL
-    SIMPLE_SETTINGS = [:workers, :queues, :min_priority, :max_priority, :sleep_delay, :read_ahead].freeze
+    SIMPLE_SETTINGS = [:workers, :queues, :min_priority, :max_priority, :sleep_delay, :read_ahead, :pooled_queues].freeze
     CALLBACK_SETTINGS = [:after_preload_app, :on_worker_boot, :after_worker_boot, :after_worker_shutdown].freeze
 
     def self.load(path)

--- a/lib/delayed_job_worker_pool/version.rb
+++ b/lib/delayed_job_worker_pool/version.rb
@@ -1,3 +1,3 @@
 module DelayedJobWorkerPool
-  VERSION = '0.2.5'.freeze
+  VERSION = '0.2.4'.freeze
 end

--- a/lib/delayed_job_worker_pool/version.rb
+++ b/lib/delayed_job_worker_pool/version.rb
@@ -1,3 +1,3 @@
 module DelayedJobWorkerPool
-  VERSION = '0.2.4'.freeze
+  VERSION = '0.2.5'.freeze
 end

--- a/lib/delayed_job_worker_pool/version.rb
+++ b/lib/delayed_job_worker_pool/version.rb
@@ -1,3 +1,3 @@
 module DelayedJobWorkerPool
-  VERSION = '0.2.4'.freeze
+  VERSION = '0.2.4'
 end

--- a/lib/delayed_job_worker_pool/worker_pool.rb
+++ b/lib/delayed_job_worker_pool/worker_pool.rb
@@ -74,7 +74,6 @@ module DelayedJobWorkerPool
 
     def load_app
       DelayedJobWorkerPool::Application.load
-      Rails.application.eager_load!
     end
 
     def shutdown(signal)

--- a/lib/delayed_job_worker_pool/worker_pool.rb
+++ b/lib/delayed_job_worker_pool/worker_pool.rb
@@ -9,8 +9,8 @@ module DelayedJobWorkerPool
       @worker_pids = []
       @worker_pid_opts = {}
       @pending_signals = []
-      @pending_signal_read_pipe, @pending_signal_write_pipe = create_pipe(inheritable: false)
-      @master_alive_read_pipe, @master_alive_write_pipe = create_pipe(inheritable: true)
+      @pending_signal_read_pipe, @pending_signal_write_pipe = create_pipe(false)
+      @master_alive_read_pipe, @master_alive_write_pipe = create_pipe
       self.shutting_down = false
     end
 
@@ -172,7 +172,7 @@ module DelayedJobWorkerPool
       opts.except(:workers, :preload_app, :pooled_queues, *DelayedJobWorkerPool::DSL::CALLBACK_SETTINGS).merge(name: worker_name(worker_pid))
     end
 
-    def create_pipe(inheritable: true)
+    def create_pipe(inheritable=true)
       read, write = IO.pipe
       unless inheritable
         make_file_descriptor_uninheritable(read)

--- a/lib/delayed_job_worker_pool/worker_pool.rb
+++ b/lib/delayed_job_worker_pool/worker_pool.rb
@@ -74,6 +74,7 @@ module DelayedJobWorkerPool
 
     def load_app
       DelayedJobWorkerPool::Application.load
+      Rails.application.eager_load!
     end
 
     def shutdown(signal)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,6 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'delayed_job_worker_pool'
+require 'tempfile'
+require 'socket'
 
 Dir['spec/support/**/*.rb'].each { |f| require File.expand_path(f) }


### PR DESCRIPTION
Current functionality allows for spawning a number of workers to service an array of Queues and have them run under a single process.

I had the need to be able to spawn multiple queues under the Master process with dedicated numbers of workers per queue (as opposed to the default x workers servicing y queues).

If you're interested in adding this functionality to your gem, I'd love your feedback on my implementation, and what you feel I need to do to make this PR "merge worthy".