### PR TITLE
Fix specs, travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: ruby
 rvm:
-  - 2.4.0
-  - 2.3.3
-  - 2.2.6
-  - 2.1.10
-  - 2.0.0-p648
-before_install: gem install bundler -v 1.13.7
+  - 2.7.1
+  - 2.6.6
+  - 2.5.8
+before_install: gem install bundler -v '~> 2.1'

--- a/delayed_job_worker_pool.gemspec
+++ b/delayed_job_worker_pool.gemspec
@@ -22,9 +22,10 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'delayed_job', ['>= 3.0', '< 4.2']
 
   spec.add_development_dependency 'delayed_job_active_record'
-  spec.add_development_dependency 'bundler', '~> 1.10'
+  spec.add_development_dependency 'bundler', '~> 2.1'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '>= 3.3'
   spec.add_development_dependency 'sqlite3', '>= 1.3'
-  spec.add_development_dependency 'rails', '>= 4.2'
+  spec.add_development_dependency 'rails', '>= 4.2', '< 6'
+  spec.add_development_dependency 'sprockets', '< 4'
 end

--- a/lib/delayed_job_worker_pool/worker_pool.rb
+++ b/lib/delayed_job_worker_pool/worker_pool.rb
@@ -1,4 +1,5 @@
 require 'fcntl'
+require 'socket'
 
 module DelayedJobWorkerPool
   class WorkerPool

--- a/spec/delayed_job_worker_pool/dsl_spec.rb
+++ b/spec/delayed_job_worker_pool/dsl_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'tempfile'
 
 describe DelayedJobWorkerPool::DSL do
 


### PR DESCRIPTION
I looked at the code in preparation for an attempt on https://github.com/salsify/delayed_job_worker_pool/pull/3 . Some side products:

* I've fixed the build on travis, needed to add some require's
* I've added Ruby 2.5.5 and pinned dependencies to keep the build green (Rails 6 and Sprockets 4 will both break it)
* Red rebuild of your current master: https://travis-ci.org/severinraez/delayed_job_worker_pool/builds/596486724
* Build of this PR: https://travis-ci.org/severinraez/delayed_job_worker_pool/builds/596494839
* Ruby 2.1 and 2.0 are failing on both master and my branch. To fix 2.1, we'd need another pin: `spec.add_development_dependency 'sqlite3', '>= 1.3', '< 1.4'`. Didn't look at 2.0. With those versions now being EOL, what do you think about dropping support for them to keep things simple?
