### PR TITLE
Add worker groups with different settings

### DIFF
--- a/lib/delayed_job_worker_pool.rb
+++ b/lib/delayed_job_worker_pool.rb
@@ -1,6 +1,8 @@
 require 'delayed_job_worker_pool/application'
 require 'delayed_job_worker_pool/dsl'
+require 'delayed_job_worker_pool/registry'
 require 'delayed_job_worker_pool/worker'
 require 'delayed_job_worker_pool/worker_info'
 require 'delayed_job_worker_pool/worker_pool'
+require 'delayed_job_worker_pool/worker_group_options'
 require 'delayed_job_worker_pool/version'

--- a/lib/delayed_job_worker_pool/dsl.rb
+++ b/lib/delayed_job_worker_pool/dsl.rb
@@ -1,29 +1,46 @@
 module DelayedJobWorkerPool
   class DSL
-    SIMPLE_SETTINGS = [:workers, :queues, :min_priority, :max_priority, :sleep_delay, :read_ahead].freeze
+    class NoWorkerGroupsDefined < StandardError; end
+    class NonUniqueGroupName < StandardError; end
+
     CALLBACK_SETTINGS = [:after_preload_app, :on_worker_boot, :after_worker_boot, :after_worker_shutdown].freeze
+    DEFAULT_WORKER_GROUP_NAME = :default
 
     def self.load(path)
       options = {}
 
       dsl = new(options)
       dsl.instance_eval(File.read(path), path, 1)
+      dsl.assert_groups_defined!
 
       options
     end
 
     def initialize(options)
       @options = options
+      @options[:worker_groups] ||= {}
     end
 
-    SIMPLE_SETTINGS.each do |option_name|
-      define_method(option_name) do |option_value|
-        @options[option_name] = option_value unless option_value.nil?
+    def preload_app(preload = true)
+      @options[:preload_app] = preload
+    end
+
+    def worker_group(name = DEFAULT_WORKER_GROUP_NAME, &block)
+      name_sym = name.to_sym
+      if @options[:worker_groups].key?(name_sym)
+        raise NonUniqueGroupName, "Worker group name #{name_sym} is already in use"
       end
+
+      group_options = WorkerGroupOptions.new
+      yield(group_options)
+      @options[:worker_groups][name_sym] = group_options
     end
 
-    def preload_app(preload_app = true)
-      @options[:preload_app] = preload_app
+    def assert_groups_defined!
+      return unless @options[:worker_groups].empty?
+
+      raise NoWorkerGroupsDefined,
+            'No worker groups defined. Define groups using `worker_group`.'
     end
 
     CALLBACK_SETTINGS.each do |option_name|

--- a/lib/delayed_job_worker_pool/registry.rb
+++ b/lib/delayed_job_worker_pool/registry.rb
@@ -1,0 +1,61 @@
+module DelayedJobWorkerPool
+  # Keeps track of worker groups and their workers.
+  class Registry
+    class GroupAlreadyExists < StandardError; end
+    class GroupDoesNotExist < StandardError; end
+    class GroupNotFound < StandardError; end
+
+    def initialize
+      @groups = {}
+    end
+
+    def include_worker?(pid)
+      worker_pids.include?(pid)
+    end
+
+    def has_workers?
+      !worker_pids.empty?
+    end
+
+    def add_group(name, options)
+      raise GroupAlreadyExists, "Group #{group} already exists" if @groups.key?(name)
+
+      @groups[name] = {
+        options: options,
+        pids: []
+      }
+    end
+
+    def add_worker(group_name, pid)
+      group_by_name(group_name)[:pids] << pid
+    end
+
+    def remove_worker(pid)
+      @groups[group(pid)][:pids].delete(pid)
+    end
+
+    def options(group_name)
+      group_by_name(group_name)[:options]
+    end
+
+    def worker_pids
+      @groups.values.flat_map{ |v| v[:pids] }
+    end
+
+    def group(pid)
+      @groups.each do |name, group|
+        return name if group[:pids].include?(pid)
+      end
+      raise GroupNotFound, "No group found for PID #{pid}"
+    end
+
+    private
+
+    def group_by_name(name)
+      match = @groups[name]
+      return match unless match.nil?
+
+      raise GroupDoesNotExist, "No group with name #{name.inspect} found"
+    end
+  end
+end

--- a/lib/delayed_job_worker_pool/worker_group_options.rb
+++ b/lib/delayed_job_worker_pool/worker_group_options.rb
@@ -1,0 +1,21 @@
+module DelayedJobWorkerPool
+  class WorkerGroupOptions
+    DJ_SETTINGS = %i[
+      queues
+      min_priority
+      max_priority
+      sleep_delay
+      read_ahead
+    ].freeze
+    GROUP_SETTINGS = %i[workers].freeze
+
+    attr_accessor *DJ_SETTINGS, *GROUP_SETTINGS
+
+    # @return an options hash for `Delayed::Worker`
+    def dj_worker_options
+      DJ_SETTINGS.each_with_object({}) do |setting, memo|
+        memo[setting] = self.send(setting)
+      end.compact
+    end
+  end
+end

--- a/lib/delayed_job_worker_pool/worker_info.rb
+++ b/lib/delayed_job_worker_pool/worker_info.rb
@@ -1,11 +1,11 @@
 module DelayedJobWorkerPool
   class WorkerInfo
-    attr_reader :process_id, :name
+    attr_reader :process_id, :name, :worker_group
 
     def initialize(attributes)
       @process_id = attributes.fetch(:process_id)
       @name = attributes.fetch(:name)
+      @worker_group = attributes.fetch(:worker_group)
     end
-
   end
 end

--- a/spec/config/multiple_groups.rb
+++ b/spec/config/multiple_groups.rb
@@ -1,0 +1,13 @@
+worker_group(:group_1) do |g|
+  g.workers = 1
+  g.queues = ENV.fetch('QUEUES_GROUP_1').split(',')
+  g.sleep_delay = 0.1
+end
+
+worker_group(:group_2) do |g|
+  g.workers = 1
+  g.queues = ENV.fetch('QUEUES_GROUP_2').split(',')
+  g.sleep_delay = 0.1
+end
+
+preload_app

--- a/spec/config/postload_app.rb
+++ b/spec/config/postload_app.rb
@@ -1,3 +1,5 @@
-workers Integer(ENV.fetch('NUM_WORKERS', 1))
-queues ENV.fetch('QUEUES', '').split(',')
-sleep_delay 0.1
+worker_group(:default) do |g|
+  g.workers = Integer(ENV.fetch('NUM_WORKERS', 1))
+  g.queues = ENV.fetch('QUEUES', '').split(',')
+  g.sleep_delay = 0.1
+end

--- a/spec/config/preload_app.rb
+++ b/spec/config/preload_app.rb
@@ -1,6 +1,8 @@
-workers Integer(ENV.fetch('NUM_WORKERS', 1))
-queues ENV.fetch('QUEUES', '').split(',')
-sleep_delay 0.1
+worker_group(:default) do |g|
+  g.workers = Integer(ENV.fetch('NUM_WORKERS', 1))
+  g.queues = ENV.fetch('QUEUES', '').split(',')
+  g.sleep_delay = 0.1
+end
 
 preload_app
 
@@ -10,7 +12,13 @@ worker_state_file = ENV.fetch('WORKER_STATE_FILE')
 
 def write_callback_log(log, callback, worker_info = nil)
   payload = { callback: callback, pid: Process.pid }
-  payload.merge!(worker_pid: worker_info.process_id, worker_name: worker_info.name) if worker_info
+  if worker_info
+    payload.merge!(
+      worker_pid: worker_info.process_id,
+      worker_name: worker_info.name,
+      worker_group: worker_info.worker_group
+    )
+  end
   IO.write(log, "#{payload.to_json}\n", mode: 'a')
 end
 

--- a/spec/delayed_job_worker_pool/registry_spec.rb
+++ b/spec/delayed_job_worker_pool/registry_spec.rb
@@ -1,0 +1,77 @@
+require 'spec_helper'
+
+describe DelayedJobWorkerPool::Registry do
+  let(:registry) { DelayedJobWorkerPool::Registry.new }
+
+  context 'empty registry' do
+    it '#has_workers?' do
+      expect(registry.has_workers?).to be_falsey
+    end
+
+    it 'adds groups and workers' do
+      registry.add_group(:group_a, {})
+      registry.add_worker(:group_a, 1)
+      expect(registry.worker_pids).to eq([1])
+      registry.add_worker(:group_a, 2)
+      expect(registry.worker_pids).to eq([1, 2])
+
+      registry.add_group(:group_b, {})
+      registry.add_worker(:group_b, 3)
+      expect(registry.worker_pids).to eq([1, 2, 3])
+    end
+  end
+
+  context 'registry with workers' do
+    before do
+      registry.add_group(:group_a, { id: :options_a })
+      registry.add_worker(:group_a, 1)
+      registry.add_worker(:group_a, 2)
+
+      registry.add_group(:group_b, { id: :options_b })
+      registry.add_worker(:group_b, 3)
+    end
+
+    it '#add_worker raises when group does not exist' do
+      expect { registry.add_worker(:unknown_group, 1) }.to raise_error(
+        DelayedJobWorkerPool::Registry::GroupDoesNotExist
+      )
+    end
+
+    it '#has_workers?' do
+      expect(registry.has_workers?).to be_truthy
+    end
+
+    it '#include_worker?' do
+      expect(registry.include_worker?(1)).to be_truthy
+      expect(registry.include_worker?(3)).to be_truthy
+      expect(registry.include_worker?(4)).to be_falsey
+    end
+
+    it '#group' do
+      expect(registry.group(1)).to eq(:group_a)
+      expect(registry.group(3)).to eq(:group_b)
+
+      expect { registry.group(10) }.to raise_error(
+        DelayedJobWorkerPool::Registry::GroupNotFound
+      )
+    end
+
+    it '#options' do
+      expect(registry.options(:group_a)).to eq({ id: :options_a })
+      expect(registry.options(:group_b)).to eq({ id: :options_b })
+    end
+
+    it '#options raises when group does not exist' do
+      expect { registry.options(:bogus_group) }.to raise_error(
+        DelayedJobWorkerPool::Registry::GroupDoesNotExist
+      )
+    end
+
+    it 'removes workers' do
+      registry.remove_worker(1)
+      expect(registry.worker_pids).to eq([2, 3])
+      registry.remove_worker(3)
+      expect(registry.worker_pids).to eq([2])
+    end
+  end
+end

--- a/spec/delayed_job_worker_pool/worker_group_options_spec.rb
+++ b/spec/delayed_job_worker_pool/worker_group_options_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+describe DelayedJobWorkerPool::WorkerGroupOptions do
+  let(:options) { DelayedJobWorkerPool::WorkerGroupOptions.new }
+
+  it '#dj_worker_options' do
+    expect(options.dj_worker_options).to eq({})
+
+    options.queues = nil
+    options.workers = 5
+
+    expect(options.dj_worker_options).to eq({})
+
+    options.queues = %w[foo]
+    expect(options.dj_worker_options).to eq({ queues: %w[foo] })
+  end
+end


### PR DESCRIPTION
A follow up to https://github.com/salsify/delayed_job_worker_pool/pull/3

I've changed the terminology to `worker_groups` so we have clear semantics. The worker pool are all the workers, a worker group is a subset of workers sharing the same options.