### PR TITLE
Enable Rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,8 @@
+inherit_gem:
+  salsify_rubocop: conf/rubocop.yml
+
+AllCops:
+  TargetRubyVersion: 2.5
+  Exclude:
+    - 'vendor/**/*'
+    - 'gemfiles/vendor/**/*'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 language: ruby
+cache: bundler
+sudo: false
 rvm:
   - 2.7.1
   - 2.6.6
   - 2.5.8
 before_install: gem install bundler -v '~> 2.1'
+script:
+  - bundle exec rspec
+  - bundle exec rubocop

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
 

--- a/bin/delayed_job_worker_pool
+++ b/bin/delayed_job_worker_pool
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 unless ARGV.size == 1
   puts "usage: #{File.basename(__FILE__)} <config>"

--- a/delayed_job_worker_pool.gemspec
+++ b/delayed_job_worker_pool.gemspec
@@ -1,5 +1,6 @@
-# coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
+# frozen_string_literal: true
+
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'delayed_job_worker_pool/version'
 
@@ -21,12 +22,12 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'delayed_job', ['>= 3.0', '< 4.2']
 
-  spec.add_development_dependency 'delayed_job_active_record'
   spec.add_development_dependency 'bundler', '~> 2.1'
+  spec.add_development_dependency 'delayed_job_active_record'
+  spec.add_development_dependency 'rails', '>= 4.2', '< 6'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '>= 3.3'
-  spec.add_development_dependency 'sqlite3', '>= 1.3'
-  spec.add_development_dependency 'rails', '>= 4.2', '< 6'
-  spec.add_development_dependency 'sprockets', '< 4'
   spec.add_development_dependency 'salsify_rubocop', '0.85.0'
+  spec.add_development_dependency 'sprockets', '< 4'
+  spec.add_development_dependency 'sqlite3', '>= 1.3'
 end

--- a/delayed_job_worker_pool.gemspec
+++ b/delayed_job_worker_pool.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.executables   = ['delayed_job_worker_pool']
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 2.0'
+  spec.required_ruby_version = '>= 2.5'
 
   spec.add_dependency 'delayed_job', ['>= 3.0', '< 4.2']
 
@@ -28,4 +28,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'sqlite3', '>= 1.3'
   spec.add_development_dependency 'rails', '>= 4.2', '< 6'
   spec.add_development_dependency 'sprockets', '< 4'
+  spec.add_development_dependency 'salsify_rubocop', '0.85.0'
 end

--- a/lib/delayed_job_worker_pool.rb
+++ b/lib/delayed_job_worker_pool.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'delayed_job_worker_pool/application'
 require 'delayed_job_worker_pool/dsl'
 require 'delayed_job_worker_pool/registry'

--- a/lib/delayed_job_worker_pool/application.rb
+++ b/lib/delayed_job_worker_pool/application.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DelayedJobWorkerPool
   module Application
     extend self
@@ -6,7 +8,7 @@ module DelayedJobWorkerPool
       require(base_application_filename)
     rescue LoadError
       raise "Could not find Rails initialization file #{full_application_filename}. " \
-            "Make sure delayed_job_worker_pool is run from the Rails root directory."
+            'Make sure delayed_job_worker_pool is run from the Rails root directory.'
     end
 
     private

--- a/lib/delayed_job_worker_pool/dsl.rb
+++ b/lib/delayed_job_worker_pool/dsl.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DelayedJobWorkerPool
   class DSL
     class NoWorkerGroupsDefined < StandardError; end
@@ -25,10 +27,10 @@ module DelayedJobWorkerPool
       @options[:preload_app] = preload
     end
 
-    def worker_group(name = DEFAULT_WORKER_GROUP_NAME, &block)
+    def worker_group(name = DEFAULT_WORKER_GROUP_NAME)
       name_sym = name.to_sym
       if @options[:worker_groups].key?(name_sym)
-        raise NonUniqueGroupName, "Worker group name #{name_sym} is already in use"
+        raise NonUniqueGroupName.new("Worker group name #{name_sym} is already in use")
       end
 
       group_options = WorkerGroupOptions.new
@@ -39,8 +41,7 @@ module DelayedJobWorkerPool
     def assert_groups_defined!
       return unless @options[:worker_groups].empty?
 
-      raise NoWorkerGroupsDefined,
-            'No worker groups defined. Define groups using `worker_group`.'
+      raise NoWorkerGroupsDefined.new('No worker groups defined. Define groups using `worker_group`.')
     end
 
     CALLBACK_SETTINGS.each do |option_name|

--- a/lib/delayed_job_worker_pool/registry.rb
+++ b/lib/delayed_job_worker_pool/registry.rb
@@ -15,7 +15,7 @@ module DelayedJobWorkerPool
       worker_pids.include?(pid)
     end
 
-    def has_workers?
+    def workers?
       !worker_pids.empty?
     end
 

--- a/lib/delayed_job_worker_pool/registry.rb
+++ b/lib/delayed_job_worker_pool/registry.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DelayedJobWorkerPool
   # Keeps track of worker groups and their workers.
   class Registry
@@ -18,7 +20,7 @@ module DelayedJobWorkerPool
     end
 
     def add_group(name, options)
-      raise GroupAlreadyExists, "Group #{group} already exists" if @groups.key?(name)
+      raise GroupAlreadyExists.new("Group #{group} already exists") if @groups.key?(name)
 
       @groups[name] = {
         options: options,
@@ -39,14 +41,14 @@ module DelayedJobWorkerPool
     end
 
     def worker_pids
-      @groups.values.flat_map{ |v| v[:pids] }
+      @groups.values.flat_map { |v| v[:pids] }
     end
 
     def group(pid)
       @groups.each do |name, group|
         return name if group[:pids].include?(pid)
       end
-      raise GroupNotFound, "No group found for PID #{pid}"
+      raise GroupNotFound.new("No group found for PID #{pid}")
     end
 
     private
@@ -55,7 +57,7 @@ module DelayedJobWorkerPool
       match = @groups[name]
       return match unless match.nil?
 
-      raise GroupDoesNotExist, "No group with name #{name.inspect} found"
+      raise GroupDoesNotExist.new("No group with name #{name.inspect} found")
     end
   end
 end

--- a/lib/delayed_job_worker_pool/version.rb
+++ b/lib/delayed_job_worker_pool/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DelayedJobWorkerPool
-  VERSION = '0.2.4'.freeze
+  VERSION = '0.2.4'
 end

--- a/lib/delayed_job_worker_pool/worker.rb
+++ b/lib/delayed_job_worker_pool/worker.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DelayedJobWorkerPool
   module Worker
     extend self

--- a/lib/delayed_job_worker_pool/worker_group_options.rb
+++ b/lib/delayed_job_worker_pool/worker_group_options.rb
@@ -1,20 +1,16 @@
+# frozen_string_literal: true
+
 module DelayedJobWorkerPool
   class WorkerGroupOptions
-    DJ_SETTINGS = %i[
-      queues
-      min_priority
-      max_priority
-      sleep_delay
-      read_ahead
-    ].freeze
-    GROUP_SETTINGS = %i[workers].freeze
+    DJ_SETTINGS = [:queues, :min_priority, :max_priority, :sleep_delay, :read_ahead].freeze
+    GROUP_SETTINGS = [:workers].freeze
 
     attr_accessor *DJ_SETTINGS, *GROUP_SETTINGS
 
     # @return an options hash for `Delayed::Worker`
     def dj_worker_options
       DJ_SETTINGS.each_with_object({}) do |setting, memo|
-        memo[setting] = self.send(setting)
+        memo[setting] = send(setting)
       end.compact
     end
   end

--- a/lib/delayed_job_worker_pool/worker_info.rb
+++ b/lib/delayed_job_worker_pool/worker_info.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DelayedJobWorkerPool
   class WorkerInfo
     attr_reader :process_id, :name, :worker_group

--- a/lib/delayed_job_worker_pool/worker_pool.rb
+++ b/lib/delayed_job_worker_pool/worker_pool.rb
@@ -66,7 +66,8 @@ module DelayedJobWorkerPool
         next if t == Thread.current
 
         if t.respond_to?(:backtrace)
-          log("WARNING: Thread will not be inherited by workers: #{t.inspect} - #{t.backtrace ? t.backtrace.first : ''}")
+          log("WARNING: Thread will not be inherited by workers: #{t.inspect} - " \
+              "#{t.backtrace ? t.backtrace.first : ''}")
         else
           log("WARNING: Thread will not be inherited by workers: #{t.inspect}")
         end
@@ -88,8 +89,8 @@ module DelayedJobWorkerPool
     end
 
     def monitor_workers
-      while has_workers?
-        if has_pending_signal?
+      while workers?
+        if pending_signal?
           shutdown(pending_signals.pop)
         elsif (wait_result = Process.wait2(-1, Process::WNOHANG))
           handle_dead_worker(wait_result.first, wait_result.last)
@@ -111,11 +112,11 @@ module DelayedJobWorkerPool
       fork_worker(group) unless shutting_down
     end
 
-    def has_workers?
-      registry.has_workers?
+    def workers?
+      registry.workers?
     end
 
-    def has_pending_signal?
+    def pending_signal?
       !pending_signals.empty?
     end
 

--- a/spec/config/multiple_groups.rb
+++ b/spec/config/multiple_groups.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 worker_group(:group_1) do |g|
   g.workers = 1
   g.queues = ENV.fetch('QUEUES_GROUP_1').split(',')

--- a/spec/config/postload_app.rb
+++ b/spec/config/postload_app.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 worker_group(:default) do |g|
   g.workers = Integer(ENV.fetch('NUM_WORKERS', 1))
   g.queues = ENV.fetch('QUEUES', '').split(',')

--- a/spec/config/preload_app.rb
+++ b/spec/config/preload_app.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 worker_group(:default) do |g|
   g.workers = Integer(ENV.fetch('NUM_WORKERS', 1))
   g.queues = ENV.fetch('QUEUES', '').split(',')

--- a/spec/delayed_job_worker_pool/application_spec.rb
+++ b/spec/delayed_job_worker_pool/application_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe DelayedJobWorkerPool::Application do

--- a/spec/delayed_job_worker_pool/dsl_spec.rb
+++ b/spec/delayed_job_worker_pool/dsl_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'tempfile'
 
@@ -5,7 +7,7 @@ describe DelayedJobWorkerPool::DSL do
 
   describe ".load" do
     describe "worker pools" do
-      it 'parses worker_group blocks' do
+      it "parses worker_group blocks" do
         options = process_dsl <<-DSL
           worker_group do |g|
             g.workers = 4
@@ -28,7 +30,7 @@ describe DelayedJobWorkerPool::DSL do
       end
     end
 
-    describe 'preload_app' do
+    describe "preload_app" do
       it "parses preload_app without any args" do
         options = process_global_dsl <<-DSL
           preload_app

--- a/spec/delayed_job_worker_pool/registry_spec.rb
+++ b/spec/delayed_job_worker_pool/registry_spec.rb
@@ -6,8 +6,8 @@ describe DelayedJobWorkerPool::Registry do
   let(:registry) { DelayedJobWorkerPool::Registry.new }
 
   context "empty registry" do
-    it '#has_workers?' do
-      expect(registry).not_to have_workers
+    it '#workers?' do
+      expect(registry).not_to be_workers
     end
 
     it "adds groups and workers" do
@@ -39,8 +39,8 @@ describe DelayedJobWorkerPool::Registry do
       )
     end
 
-    it '#has_workers?' do
-      expect(registry).to have_workers
+    it '#workers?' do
+      expect(registry).to be_workers
     end
 
     it '#include_worker?' do

--- a/spec/delayed_job_worker_pool/registry_spec.rb
+++ b/spec/delayed_job_worker_pool/registry_spec.rb
@@ -1,14 +1,16 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe DelayedJobWorkerPool::Registry do
   let(:registry) { DelayedJobWorkerPool::Registry.new }
 
-  context 'empty registry' do
+  context "empty registry" do
     it '#has_workers?' do
-      expect(registry.has_workers?).to be_falsey
+      expect(registry).not_to have_workers
     end
 
-    it 'adds groups and workers' do
+    it "adds groups and workers" do
       registry.add_group(:group_a, {})
       registry.add_worker(:group_a, 1)
       expect(registry.worker_pids).to eq([1])
@@ -21,7 +23,7 @@ describe DelayedJobWorkerPool::Registry do
     end
   end
 
-  context 'registry with workers' do
+  context "registry with workers" do
     before do
       registry.add_group(:group_a, { id: :options_a })
       registry.add_worker(:group_a, 1)
@@ -38,13 +40,13 @@ describe DelayedJobWorkerPool::Registry do
     end
 
     it '#has_workers?' do
-      expect(registry.has_workers?).to be_truthy
+      expect(registry).to have_workers
     end
 
     it '#include_worker?' do
-      expect(registry.include_worker?(1)).to be_truthy
-      expect(registry.include_worker?(3)).to be_truthy
-      expect(registry.include_worker?(4)).to be_falsey
+      expect(registry).to be_include_worker(1)
+      expect(registry).to be_include_worker(3)
+      expect(registry).not_to be_include_worker(4)
     end
 
     it '#group' do
@@ -67,7 +69,7 @@ describe DelayedJobWorkerPool::Registry do
       )
     end
 
-    it 'removes workers' do
+    it "removes workers" do
       registry.remove_worker(1)
       expect(registry.worker_pids).to eq([2, 3])
       registry.remove_worker(3)

--- a/spec/delayed_job_worker_pool/worker_group_options_spec.rb
+++ b/spec/delayed_job_worker_pool/worker_group_options_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe DelayedJobWorkerPool::WorkerGroupOptions do
@@ -11,7 +13,7 @@ describe DelayedJobWorkerPool::WorkerGroupOptions do
 
     expect(options.dj_worker_options).to eq({})
 
-    options.queues = %w[foo]
-    expect(options.dj_worker_options).to eq({ queues: %w[foo] })
+    options.queues = ['foo']
+    expect(options.dj_worker_options).to eq({ queues: ['foo'] })
   end
 end

--- a/spec/dummy/Rakefile
+++ b/spec/dummy/Rakefile
@@ -1,6 +1,8 @@
+# frozen_string_literal: true
+
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
-require File.expand_path('../config/application', __FILE__)
+require File.expand_path('config/application', __dir__)
 
 Rails.application.load_tasks

--- a/spec/dummy/app/controllers/application_controller.rb
+++ b/spec/dummy/app/controllers/application_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.

--- a/spec/dummy/app/helpers/application_helper.rb
+++ b/spec/dummy/app/helpers/application_helper.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 module ApplicationHelper
 end

--- a/spec/dummy/app/jobs/touch_file_job.rb
+++ b/spec/dummy/app/jobs/touch_file_job.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class TouchFileJob < Struct.new(:file)
   def perform
     Rails.logger.info("Touching #{file}")

--- a/spec/dummy/bin/bundle
+++ b/spec/dummy/bin/bundle
@@ -1,3 +1,5 @@
 #!/usr/bin/env ruby
-ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
+# frozen_string_literal: true
+
+ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 load Gem.bin_path('bundler', 'bundle')

--- a/spec/dummy/bin/delayed_job
+++ b/spec/dummy/bin/delayed_job
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require File.expand_path(File.join(File.dirname(__FILE__), '..', 'config', 'environment'))
 require 'delayed/command'

--- a/spec/dummy/bin/rails
+++ b/spec/dummy/bin/rails
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
-APP_PATH = File.expand_path('../../config/application',  __FILE__)
+# frozen_string_literal: true
+
+APP_PATH = File.expand_path('../config/application', __dir__)
 require_relative '../config/boot'
 require 'rails/commands'

--- a/spec/dummy/bin/rake
+++ b/spec/dummy/bin/rake
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
+
 require_relative '../config/boot'
 require 'rake'
 Rake.application.run

--- a/spec/dummy/config.ru
+++ b/spec/dummy/config.ru
@@ -1,4 +1,6 @@
+# frozen_string_literal: true
+
 # This file is used by Rack-based servers to start the application.
 
-require ::File.expand_path('../config/environment',  __FILE__)
+require ::File.expand_path('../config/environment', __FILE__)
 run Rails.application

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -1,4 +1,6 @@
-require File.expand_path('../boot', __FILE__)
+# frozen_string_literal: true
+
+require File.expand_path('boot', __dir__)
 
 require 'rails/all'
 
@@ -19,4 +21,3 @@ module Dummy
     # config.i18n.default_locale = :de
   end
 end
-

--- a/spec/dummy/config/boot.rb
+++ b/spec/dummy/config/boot.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 # Set up gems listed in the Gemfile.
-ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../../../Gemfile', __FILE__)
+ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../../Gemfile', __dir__)
 
 require 'bundler/setup' if File.exist?(ENV['BUNDLE_GEMFILE'])
-$LOAD_PATH.unshift File.expand_path('../../../../lib', __FILE__)
+$LOAD_PATH.unshift File.expand_path('../../../lib', __dir__)

--- a/spec/dummy/config/environment.rb
+++ b/spec/dummy/config/environment.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 # Load the Rails application.
-require File.expand_path('../application', __FILE__)
+require File.expand_path('application', __dir__)
 
 # Initialize the Rails application.
 Rails.application.initialize!

--- a/spec/dummy/config/environments/development.rb
+++ b/spec/dummy/config/environments/development.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 

--- a/spec/dummy/config/environments/production.rb
+++ b/spec/dummy/config/environments/production.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 

--- a/spec/dummy/config/environments/test.rb
+++ b/spec/dummy/config/environments/test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 

--- a/spec/dummy/config/initializers/assets.rb
+++ b/spec/dummy/config/initializers/assets.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Version of your assets, change this if you want to expire all your assets.

--- a/spec/dummy/config/initializers/backtrace_silencers.rb
+++ b/spec/dummy/config/initializers/backtrace_silencers.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Be sure to restart your server when you modify this file.
 
 # You can add backtrace silencers for libraries that you're using but don't wish to see in your backtraces.

--- a/spec/dummy/config/initializers/cookies_serializer.rb
+++ b/spec/dummy/config/initializers/cookies_serializer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 Rails.application.config.action_dispatch.cookies_serializer = :json

--- a/spec/dummy/config/initializers/filter_parameter_logging.rb
+++ b/spec/dummy/config/initializers/filter_parameter_logging.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Configure sensitive parameters which will be filtered from the log file.

--- a/spec/dummy/config/initializers/inflections.rb
+++ b/spec/dummy/config/initializers/inflections.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Be sure to restart your server when you modify this file.
 
 # Add new inflection rules using the following format. Inflections

--- a/spec/dummy/config/initializers/mime_types.rb
+++ b/spec/dummy/config/initializers/mime_types.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Be sure to restart your server when you modify this file.
 
 # Add new mime types for use in respond_to blocks:

--- a/spec/dummy/config/initializers/session_store.rb
+++ b/spec/dummy/config/initializers/session_store.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 Rails.application.config.session_store :cookie_store, key: '_dummy_session'

--- a/spec/dummy/config/initializers/wrap_parameters.rb
+++ b/spec/dummy/config/initializers/wrap_parameters.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # This file contains settings for ActionController::ParamsWrapper which

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Rails.application.routes.draw do
   # The priority is based upon order of creation: first created -> highest priority.
   # See how all your routes lay out with "rake routes".

--- a/spec/dummy/db/migrate/20150817172203_create_delayed_jobs.rb
+++ b/spec/dummy/db/migrate/20150817172203_create_delayed_jobs.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateDelayedJobs < ActiveRecord::Migration
   def self.up
     create_table :delayed_jobs, force: true do |table|
@@ -13,7 +15,7 @@ class CreateDelayedJobs < ActiveRecord::Migration
       table.timestamps null: true
     end
 
-    add_index :delayed_jobs, [:priority, :run_at], name: "delayed_jobs_priority"
+    add_index :delayed_jobs, [:priority, :run_at], name: 'delayed_jobs_priority'
   end
 
   def self.down

--- a/spec/dummy/db/migrate/20150817172203_create_delayed_jobs.rb
+++ b/spec/dummy/db/migrate/20150817172203_create_delayed_jobs.rb
@@ -3,15 +3,15 @@
 class CreateDelayedJobs < ActiveRecord::Migration
   def self.up
     create_table :delayed_jobs, force: true do |table|
-      table.integer :priority, default: 0, null: false # Allows some jobs to jump to the front of the queue
-      table.integer :attempts, default: 0, null: false # Provides for retries, but still fail eventually.
-      table.text :handler,                 null: false # YAML-encoded string of the object that will do work
-      table.text :last_error                           # reason for last failure (See Note below)
-      table.datetime :run_at                           # When to run. Could be Time.zone.now for immediately, or sometime in the future.
-      table.datetime :locked_at                        # Set when a client is working on this object
-      table.datetime :failed_at                        # Set when all retries have failed (actually, by default, the record is deleted instead)
-      table.string :locked_by                          # Who is working on this object (if locked)
-      table.string :queue                              # The name of the queue this job is in
+      table.integer :priority, default: 0, null: false
+      table.integer :attempts, default: 0, null: false
+      table.text :handler, null: false
+      table.text :last_error
+      table.datetime :run_at
+      table.datetime :locked_at
+      table.datetime :failed_at
+      table.string :locked_by
+      table.string :queue
       table.timestamps null: true
     end
 

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -1,4 +1,5 @@
-# encoding: UTF-8
+# frozen_string_literal: true
+
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -13,20 +14,20 @@
 
 ActiveRecord::Schema.define(version: 20150817172203) do
 
-  create_table "delayed_jobs", force: :cascade do |t|
-    t.integer  "priority",   default: 0, null: false
-    t.integer  "attempts",   default: 0, null: false
-    t.text     "handler",                null: false
-    t.text     "last_error"
-    t.datetime "run_at"
-    t.datetime "locked_at"
-    t.datetime "failed_at"
-    t.string   "locked_by"
-    t.string   "queue"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+  create_table 'delayed_jobs', force: :cascade do |t|
+    t.integer  'priority',   default: 0, null: false
+    t.integer  'attempts',   default: 0, null: false
+    t.text     'handler',                null: false
+    t.text     'last_error'
+    t.datetime 'run_at'
+    t.datetime 'locked_at'
+    t.datetime 'failed_at'
+    t.string   'locked_by'
+    t.string   'queue'
+    t.datetime 'created_at'
+    t.datetime 'updated_at'
   end
 
-  add_index "delayed_jobs", ["priority", "run_at"], name: "delayed_jobs_priority"
+  add_index 'delayed_jobs', ['priority', 'run_at'], name: 'delayed_jobs_priority'
 
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,6 @@
-$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
+# frozen_string_literal: true
+
+$LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 require 'delayed_job_worker_pool'
 
 Dir['spec/support/**/*.rb'].each { |f| require File.expand_path(f) }

--- a/spec/support/wait.rb
+++ b/spec/support/wait.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Wait
   extend self
 


### PR DESCRIPTION
This PR enables Rubocop and sets our minimum Ruby version to 2.5 to reflect the testing we're doing after https://github.com/salsify/delayed_job_worker_pool/pull/4. The PR is broken up into 3 commits:

1. Adding Rubocop
2. Auto-correcting errors
3. Manually correcting the remaining errors